### PR TITLE
Moving popinContextType* APIs to Window

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,15 +133,15 @@ enum PopinContextType { "partitioned" };
 
 A draft API for feature detection by a prospective popin opener could look like:
 ```
-interface Navigator {
+partial interface Window {
   // Returns an empty array if no popin context types are supported.
-  Array<PopinContextType> popinContextTypesSupported();
+  sequence<PopinContextType> popinContextTypesSupported();
 };
 ```
 
 A draft API for a popin to detect it is a popin could look like:
 ```
-interface Navigator {
+partial interface Navigator {
   // Returns null if this isn't a popin context.
   PopinContextType? popinContextType();
 };

--- a/README.md
+++ b/README.md
@@ -141,7 +141,7 @@ partial interface Window {
 
 A draft API for a popin to detect it is a popin could look like:
 ```
-partial interface Navigator {
+partial interface Window {
   // Returns null if this isn't a popin context.
   PopinContextType? popinContextType();
 };


### PR DESCRIPTION
This change updates the spec to expose popinContextType*
methods through Window, instead of Navigator.